### PR TITLE
Add links to other gems in the Google API helpers series

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: CI Build
 
 on:
   push:
@@ -6,22 +6,55 @@ on:
       - main
 
   pull_request:
+     branches: [ main ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    continue-on-error: true
+
     strategy:
       matrix:
-        ruby:
-          - '3.2.2'
+        ruby: ['3.1', '3.2', head]
+        operating-system: [ubuntu-latest]
+
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Run the default task
-      run: bundle exec rake
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run rake
+        run: bundle exec rake
+
+  coverage:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    name: Report test coverage to CodeClimate
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake spec
+
+      - name: Report test coverage
+        uses: paambaati/codeclimate-action@v3.2.0
+        env:
+          CC_TEST_REPORTER_ID: 9cee910e20024e0fcb3a6a4ad2e7a71a2031409adac7134e196627bf2ccecf02
+        with:
+          coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@
 
 Unofficial helpers and extensions for the Google Discovery V1 API
 
+Gems in the Google API helper, extensions, and examples series:
+
+* [discovery_v1](https://github.com/main-branch/discovery_v1)
+* [drive_v3](https://github.com/main-branch/drive_v3)
+* [sheets_v4](https://github.com/main-branch/sheets_v4)
+
+## Contents
+
+* [Contents](#contents)
 * [Installation](#installation)
 * [Examples](#examples)
 * [Important links](#important-links)


### PR DESCRIPTION
In the project's README.md, add links to all the gems in the Google API helper, extensions, and examples series:

* [discovery_v1](https://github.com/main-branch/discovery_v1)
* [drive_v3](https://github.com/main-branch/drive_v3)
* [sheets_v4](https://github.com/main-branch/sheets_v4)