### PR TITLE
Enforce the use of semver tags on PRs

### DIFF
--- a/.github/workflows/semver_pr_label_check.yml
+++ b/.github/workflows/semver_pr_label_check.yml
@@ -1,0 +1,12 @@
+name: Semver PR Label Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  run_semver_pr_label_check:
+    uses: main-branch/semver_pr_label_check/.github/workflows/semver_pr_label_check.yml@v1
+    secrets:
+      repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a new workflow that enforces the use of semver tags on pull requests. 

The workflow runs on the main branch and triggers on various events such as PR opening, synchronization, reopening, labeling, and unlabling. 

The workflow uses the `semver_pr_label_check` action. 

This addition ensures that all PRs follow the semver tagging convention, improving the consistency and clarity of versioning in the project.