### PR TITLE
Standardize YARD and Markdown Lint configurations

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,25 @@
+default: true
+
+# Unordered list indentation
+MD007: { indent: 2 }
+
+# Line length
+MD013: { line_length: 90, tables: false, code_blocks: false }
+
+# Heading duplication is allowed for non-sibling headings
+MD024: { siblings_only: true }
+
+# Do not allow the specified trailing punctuation in a header
+MD026: { punctuation: '.,;:' }
+
+# Order list items must have a prefix that increases in numerical order
+MD029: { style: 'ordered' }
+
+# Lists do not need to be surrounded by blank lines
+MD032: false
+
+# Allow raw HTML in Markdown
+MD033: false
+
+# Allow emphasis to be used instead of a heading
+MD036: false

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--hide-void-return
+--markup-provider=redcarpet
+--markup markdown
+--exclude examples/**
+- CHANGELOG.md
+- CONTRIBUTING.md
+- RELEASING.md
+- LICENSE.txt


### PR DESCRIPTION
Add standard `.yardopts` file and `.markdownlint.yml` file to this project so that all `main-branch` projects have the same configuration for editing and generating YARD and other Markdown documentation.