### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ Changes for each release are listed in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/) for its releases.
 
+## v0.2.0 (2024-10-11)
+
+[Full Changelog](https://github.com/main-branch/discovery_v1/compare/v0.1.0..v0.2.0)
+
+Changes since v0.1.0:
+
+* fbd2c75 build: remove semver pr label check
+* 9234cb0 build: enforce conventional commit message formatting
+* 70c72f9 Use shared Rubocop config (#16)
+* 101cb6c Update copyright notice in this project (#15)
+* 32986c4 Update links in gemspec (#14)
+* ee4305f Add Slack badge for this project in README (#13)
+* 1e05724 Use standard badges at the top of the README (#12)
+* 02ec62a Update yardopts with new standard options (#11)
+* 8b65f81 Standardize YARD and Markdown Lint configurations (#10)
+* d105374 Update CODEOWNERS file (#9)
+* 870934e Set JRuby --debug option when running tests in GitHub Actions workflows (#8)
+* 351659c Integrate simplecov-rspec into the project (#7)
+* 3ca83ee Update continuous integration and experimental ruby builds (#6)
+* cb454b8 Enforce the use of semver tags on PRs (#5)
+* 68d0136 Auto correct rubocop Gemspec/AddRuntimeDependency offense (#4)
+* 5c4115a Add links to other gems in the Google API helpers series (#3)
+* 2aa6534 Merge pull request #2 from main-branch/document_extensions
+* 92d158c Document extensions to Google::Apis::DiscoveryV1 classes
+
 ## v0.1.0 (2023-11-21)
 
 [Full Changelog](https://github.com/main-branch/discovery_v1/compare/6e9fb12..v0.1.0)

--- a/lib/discovery_v1/version.rb
+++ b/lib/discovery_v1/version.rb
@@ -2,5 +2,5 @@
 
 module DiscoveryV1
   # The version of this gem
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
# Release PR

## v0.2.0 (2024-10-11)

[Full Changelog](https://github.com/main-branch/discovery_v1/compare/v0.1.0..v0.2.0)

Changes since v0.1.0:

* fbd2c75 build: remove semver pr label check
* 9234cb0 build: enforce conventional commit message formatting
* 70c72f9 Use shared Rubocop config (#16)
* 101cb6c Update copyright notice in this project (#15)
* 32986c4 Update links in gemspec (#14)
* ee4305f Add Slack badge for this project in README (#13)
* 1e05724 Use standard badges at the top of the README (#12)
* 02ec62a Update yardopts with new standard options (#11)
* 8b65f81 Standardize YARD and Markdown Lint configurations (#10)
* d105374 Update CODEOWNERS file (#9)
* 870934e Set JRuby --debug option when running tests in GitHub Actions workflows (#8)
* 351659c Integrate simplecov-rspec into the project (#7)
* 3ca83ee Update continuous integration and experimental ruby builds (#6)
* cb454b8 Enforce the use of semver tags on PRs (#5)
* 68d0136 Auto correct rubocop Gemspec/AddRuntimeDependency offense (#4)
* 5c4115a Add links to other gems in the Google API helpers series (#3)
* 2aa6534 Merge pull request #2 from main-branch/document_extensions
* 92d158c Document extensions to Google::Apis::DiscoveryV1 classes
